### PR TITLE
Add MPM module to keep current httpd image happy

### DIFF
--- a/build-environment/apache/httpd.conf
+++ b/build-environment/apache/httpd.conf
@@ -168,6 +168,10 @@ LoadModule autoindex_module modules/mod_autoindex.so
 #LoadModule asis_module modules/mod_asis.so
 #LoadModule info_module modules/mod_info.so
 #LoadModule suexec_module modules/mod_suexec.so
+# any of these three should work, but one is required:
+#LoadModule mpm_event_module modules/mod_mpm_event.so
+#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule mpm_worker_module modules/mod_mpm_worker.so
 <IfModule !mpm_prefork_module>
   #LoadModule cgid_module modules/mod_cgid.so
 </IfModule>


### PR DESCRIPTION
Without an MPM module loaded, the httpd server stops immediately, and the error is visible like this:

    $ docker logs 123
    AH00534: httpd: Configuration error: No MPM loaded.