### PR TITLE
Remove left and right padding to improve center alignment

### DIFF
--- a/assets/src/scss/main.scss
+++ b/assets/src/scss/main.scss
@@ -296,11 +296,6 @@ nav {
         }
       }
       span.longname { @include hide-onmobile-then(inline); }
-      a {
-        padding: 0 12px 0 46px;
-        @include respond(3) { padding-right: 22px; }
-        @include respond(4) { padding-right: 34px; }
-      }
     }
     a {
       @extend %vcenter-child;
@@ -645,9 +640,6 @@ a.gallery-item {
   @include respond(3) {
     margin-left: -$double;
     margin-right: -$double;
-  }
-  @include respond(4) {
-    text-align: left;
   }
 
   .gallery-item {


### PR DESCRIPTION
Trivial tweak as an excuse to try out cap-static -- removes extra left padding from nav list, and left centering of gallery-crl, so centering of blocks on the page is more consistent.

Before:

<img width="1070" alt="screen shot 2018-06-18 at 11 05 10 am" src="https://user-images.githubusercontent.com/376272/41545086-5ac77d0c-72e8-11e8-9704-dbce0c0a15c7.png">

After:

<img width="1107" alt="screen shot 2018-06-18 at 11 03 30 am" src="https://user-images.githubusercontent.com/376272/41545100-5fd6c6ae-72e8-11e8-8502-e5f9789c4211.png">
