### PR TITLE
Content tweaks

### DIFF
--- a/app/_includes/dive-in-section.html
+++ b/app/_includes/dive-in-section.html
@@ -6,18 +6,6 @@
 <div class="background gallery-crl">
   <div class="gallery-thirds gallery-item">
     <span class="title">
-      BULK DATA DOWNLOAD
-    </span>
-    Want to explore the Arkansas dataset?
-    Click here to download sample volumes.
-    <a href="https://github.com/harvard-lil/CAP_Sample_Volumes_Arkansas/"
-       role="button"
-       aria-label="Arkansas sample dataset">
-      <span>DOWNLOAD DATA</span>
-    </a>
-  </div>
-  <div class="gallery-thirds gallery-item">
-    <span class="title">
       USE THE API
     </span>
     Browse unlimited metadata and register to download up to 500 cases per day.
@@ -29,7 +17,29 @@
   </div>
   <div class="gallery-thirds gallery-item">
     <span class="title">
-      MORE
+      SEE SAMPLE DATA
+    </span>
+    Browse a documented example of one of our volumes.
+    <a href="https://github.com/harvard-lil/CAP_Sample_Volumes_Arkansas/"
+       role="button"
+       aria-label="Arkansas sample dataset">
+      <span>SEE SAMPLE</span>
+    </a>
+  </div>
+  <div class="gallery-thirds gallery-item">
+    <span class="title">
+      DOWNLOAD BULK DATA
+    </span>
+    Download zip files of our case XML.
+    <a href="https://capapi.org/bulk-access/"
+       role="button"
+       aria-label="Bulk data download">
+      <span>DOWNLOAD</span>
+    </a>
+  </div>
+  <div class="gallery-thirds gallery-item">
+    <span class="title">
+      UNLIMITED ACCESS
     </span>
     For researchers: if you need more access than the API provides, please contact us.
     <a href="mailto:info@capapi.org"

--- a/app/_includes/explorations-section.html
+++ b/app/_includes/explorations-section.html
@@ -26,4 +26,12 @@
     </a>
     Generate rhymes using caselaw!
   </div>
+  <div class="gallery-item">
+    <a href="https://capapi.org/data/">
+      <span class="title">
+        CASES BY YEAR
+      </span>
+    </a>
+    See how many cases we have by state and year
+  </div>
 </div>

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -13,3 +13,4 @@
          src="{{ site.baseurl }}/assets/images/LIL-logo.png">
   </a>
 </header>
+<div class="header-offset"></div>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -10,18 +10,18 @@
       <!--</a>-->
     <!--</li>-->
     <!--{% endif %}-->
-    <li>
-        <a class="highlighted"
-           href="/#dive-in">
-          DIVE IN!
-        </a>
-    </li>
-    <li>
-        <a href="/#explorations">EXPLORE</a>
-    </li>
-    <li>
-        <a href="/#footer">INFO</a>
-    </li>
+    <!--<li>-->
+        <!--<a class="highlighted"-->
+           <!--href="/#dive-in">-->
+          <!--DIVE IN!-->
+        <!--</a>-->
+    <!--</li>-->
+    <!--<li>-->
+        <!--<a href="/#explorations">EXPLORE</a>-->
+    <!--</li>-->
+    <!--<li>-->
+        <!--<a href="/#footer">INFO</a>-->
+    <!--</li>-->
     <!--{% if page.slug != "home" %}-->
     <!--<li>-->
       <!--<a href="{{ site.lilurl }}/" class="header-img right-align">-->

--- a/assets/src/scss/main.scss
+++ b/assets/src/scss/main.scss
@@ -242,6 +242,10 @@ header {
   }
 }
 
+.header-offset{
+  height:40px;
+}
+
 .anchor-offset {
   top: -160px;
 }
@@ -323,7 +327,7 @@ nav {
 
 .hero-splash {
   text-align: center;
-  margin-top: 100px;
+  margin-top: 60px;
   .hero-subtitle {
     @include heading-secondary;
     font-family: $font-light;


### PR DESCRIPTION
- Stop content from being covered by navbar on exploration pages
- Hide the in-page navbar on the homepage since there are only two short sections being shown right now
- Add links to the bulk download page and the data visualization page (let's launch that! I know it's not done!)

<img width="742" alt="screen shot 2018-06-21 at 12 11 34 pm" src="https://user-images.githubusercontent.com/376272/41731465-7ad08e0c-754c-11e8-8613-5b6c442ecd85.png">
